### PR TITLE
Trajectory generator update

### DIFF
--- a/pysplit/__init__.py
+++ b/pysplit/__init__.py
@@ -28,11 +28,7 @@ __all__ = ['Trajectory',
            'load_hysplitfile',
            'trajsplit',
            'load_clusteringresults',
-           'generate_trajectories',
-           'forwards_and_backwards',
-           'clip_traj',
-           'try_to_remove',
-           'meteofile_lister']
+           'generate_bulktraj']
 
 
 from .traj import Trajectory
@@ -54,6 +50,4 @@ from .hy_processor import make_trajectorygroup, spawn_clusters
 from .hyfile_handler import (hysplit_filelister, load_hysplitfile, trajsplit,
                              load_clusteringresults)
 
-from .trajectory_generator import (generate_trajectories,
-                                   forwards_and_backwards, clip_traj,
-                                   try_to_remove, meteofile_lister)
+from .trajectory_generator import (generate_bulktraj)


### PR DESCRIPTION
Overhauled trajectory generator module!

* Efficiency improvements
* Accessory functions to main trajectory generator function hidden to improve overall package usability
* New features:
  * Use *any* weekly or semi-monthly meteorology file that has a signature of '\*mon\*YY\*#', where '#' refers to the number of the file within the month, 'mon' is the month's lowercase three letter abbreviation (e.g. 'jan'), and '\*' is a Bash-style wildcard
  * Provide a slice object and generate trajectories for a particular range of days and/or every nth day of each month

Previously, users could only use gdas1 data and had to generate trajectories for every day in each month.