### PR TITLE
ENH: Allow creation of TrajectoryGroup from iterable of specific filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+*version.py
+*.egg-info*


### PR DESCRIPTION
Previously, TrajectoryGroup classes required a wildcard path and gobbled up all files matching that pattern. 

In some case one might wants to analyze a specific subgroup of files identified by some other means. This patch allows TrajectoryGroup generation from a specific set of file names, with backwards compatibility.