### PR TITLE
HyPath no longer geodataframe subclass, new sub method HyGroup, doc e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ A package for generating [HYSPLIT] (http://ready.arl.noaa.gov/HYSPLIT.php) air p
 
 * PySPLIT now uses the power of GeoPandas rather than pure NumPy
 * Faster trajectory file loading/``Trajectory`` object initialization
+* Need help clustering?  ``pysplit.print_clusteringprocedure()``.
 * The class structure of PySPLIT has been rewritten:
-  * ``Trajectory`` and ``Cluster`` objects are now subclasses of ``HyPath`` class, which in turn is a [GeoPandas] (http://geopandas.org/) ``GeoDataFrame`` subclass.
-  * ``TrajectoryGroup`` and ``Cluster`` classes are now subclasses of the ``HyGroup`` class.
+  * ``Trajectory`` and ``Cluster`` objects are now subclasses of ``HyPath`` class.
+  * Along-trajectory data for ``HyPath`` classes lives in the ``data`` attribute, a [GeoPandas] (http://geopandas.org/) ``GeoDataFrame``.
+  * ``TrajectoryGroup`` and ``Cluster`` classes are now subclasses of the ``HyGroup`` class.  They are both iterable; they can also be added together or subtracted.
   * ``HyPath`` and ``HyGroup`` are only used internally, so the API remains essentially the same.
-* ``Cluster`` objects are no longer iterable over their member ``Trajectory`` objects (instead iterate over ``Cluster.trajectories``)
 * Trajectory generator updates:
   * Improved efficiency
   * Improved API

--- a/pysplit/__init__.py
+++ b/pysplit/__init__.py
@@ -9,6 +9,7 @@ meteorological data along trajectories.
 
 __all__ = ['Trajectory',
            'TrajectoryGroup',
+           'print_clusterprocedure',
            'Cluster',
            'ClusterGroup',
            'MapDesign',
@@ -35,7 +36,7 @@ from .traj import Trajectory
 
 from .trajgroup import TrajectoryGroup
 
-from .clusgroup import Cluster, ClusterGroup
+from .clusgroup import print_clusterprocedure, Cluster, ClusterGroup
 
 from .mapdesigner import MapDesign
 

--- a/pysplit/clusgroup.py
+++ b/pysplit/clusgroup.py
@@ -3,28 +3,25 @@ from trajgroup import TrajectoryGroup
 from hypath import HyPath
 from hygroup import HyGroup
 
-"""
-Procedure
----------
-In ``PySPLIT``
-1.  Create ``TrajectoryGroup`` with desired set of trajectories
-2.  ``TrajectoryGroup.make_infile()``
 
-In ``HYSPLIT``
-3.  Trajectory --> Special Runs --> Clustering --> Standard
-4.  Adjust clustering parameters, endpoints (trajectory) folder, and
-    working folder (where output will be stored)
-5.  ``Run cluster analysis`` and determine  and set appropriate
-    number of clusters
-6.  Assign trajectories to clusters (``Run``)
-7.  ``Display Means`` and ``Display Clusters``, ``Quit``
+def print_clusterprocedure():
+    """Print clustering guide."""
+    print("""
+          In ``PySPLIT``
+          1. Create ``TrajectoryGroup`` with desired set of trajectories
+          2. ``TrajectoryGroup.make_infile()``
 
-In ``PySPLIT``
-8.  ``spawn_clusters(TrajectoryGroup, distribution_file, endpoint_dir)``
+          In ``HYSPLIT``
+          3. Trajectory --> Special Runs --> Clustering --> Standard
+          4. Adjust clustering parameters, endpoints (trajectory) folder, and
+             working folder (where output will be stored, where INFILE lives)
+          5. ``Run cluster analysis``
+          6. Determine and set appropriate number of clusters
+          7. Assign trajectories to clusters (``Run``)
+          8. ``Display Means``, ``Display Clusters``, ``Quit``
 
-This creates a ``ClusterGroup`` populated by ``Cluster``s.
-
-"""
+          In ``PySPLIT``
+          9. ``spawn_clusters()``""")
 
 
 class Cluster(HyPath, HyGroup):
@@ -33,9 +30,6 @@ class Cluster(HyPath, HyGroup):
 
     Clusters contain both trajectories and mean path information.  The mean
     path and the trajectory composition is determined by ``HySPLIT``.
-
-    Clusters are not iterable over trajectories in order to avoid
-    conflicts with the path data.
 
     """
 
@@ -55,51 +49,94 @@ class Cluster(HyPath, HyGroup):
         """
         HyPath.__init__(self, clusterdata, pathdata, datetime,
                         clusterheader)
-        # Initializes self.trajectories, self.trajcount, and self.directory
+
         HyGroup.__init__(self, trajectories)
 
-        self.start_longitude = self.trajectories[0].loc[0, 'geometry'].x
+        self.start_longitude = self.trajectories[0].data.loc[0, 'geometry'].x
         self.clusternumber = cluster_number
 
-    def addgroups(self, other):
+    def __getitem__(self, index):
         """
-        Prints notice before calling ``HyGroup.addgroups()``
+        Get ``Trajectory`` or ``TrajectoryGroup``.
 
         Parameters
         ----------
-        other : ``TrajectoryGroup``
-            Another ``TrajectoryGroup`` or ``Cluster``
+        index : int or slice
+
+        Returns
+        -------
+        ``Trajectory`` or ``TrajectoryGroup`` depending if indexed
+        or sliced.  Won't return a ``Cluster`` because those are
+        specially defined.
 
         """
+        newthing = self.trajectories[index]
 
-        print("Basic TrajectoryGroup created, cluster methods unavailable")
+        if isinstance(newthing, list):
+            newthing = TrajectoryGroup(newthing)
 
-        # Initializes self.trajectories, self.trajcount, and self.directory
-        new_tg = TrajectoryGroup(HyGroup.addgroups(self, other))
+        return newthing
 
-        return new_tg
+    def __add__(self, other):
+        """
+        Add a ``HyGroup`` to this ``Cluster`` instance.
+
+        Parameters
+        ----------
+        other : ``HyGroup``
+            Another ``TrajectoryGroup`` or ``Cluster``.  May or may not
+            contain some of the same ``Trajectory`` instances.
+
+        Returns
+        -------
+        A new ``TrajectoryGroup`` containing the union of the sets
+        of ``Trajectory`` instances.
+
+        """
+        return TrajectoryGroup(HyGroup.__add__(self, other))
+
+    def __sub__(self, other):
+        """
+        Subtract a ``HyGroup`` from this ``Cluster`` instance.
+
+        Parameters
+        ----------
+        other : ``HyGroup``
+            Another ``Cluster`` or ``TrajectoryGroup``
+
+        Returns
+        -------
+        A new ``TrajectoryGroup`` containing the set difference betwee
+        the sets of ``Trajectory`` instances.
+
+        """
+        return TrajectoryGroup(HyGroup.__sub__(self, other))
 
     def calculate_vector(self):
         """
-        Calculate mean bearing of ``Cluster`` path and bearings between
-            timesteps
+        Calculate bearings.
+
+        Find mean bearing of ``Cluster`` path and bearings between
+            timesteps.
 
         """
-
         HyPath.calculate_vector(self)
 
     def calculate_distance(self):
         """
-        Calculate the distance between timesteps fo the ``Cluster`` path and
-            the cumulative distance at each time step
+        Calculate distances.
+
+        Find the distance between timesteps of the ``Cluster`` path and
+            the cumulative distance at each time step.
 
         """
-
         HyPath.calculate_distance(self)
 
 
 class ClusterGroup(object):
     """
+    Group of ``Cluster`` instances.
+
     Contains all the ``Cluster``s produced in one ``HYSPLIT`` cluster analysis.
 
     """
@@ -112,21 +149,20 @@ class ClusterGroup(object):
         ----------
         clusters : list of ``Cluster`` instances
             ``Cluster`` instances from the same HYSPLIT clustering run.
+
         """
-
         self.clusters = clusters
-
         self.clustercount = len(clusters)
-
         self.trajcount = sum([c.trajcount for c in self.clusters])
 
     def __getitem__(self, index):
         """
+        Get ``Cluster`` or ``ClusterGroup``.
+
         Index or slice ``self.clusters`` to get a ``Cluster`` or
         ``ClusterGroup``, respectively.
 
         """
-
         newthing = self.clusters[index]
 
         try:

--- a/pysplit/hyfile_handler.py
+++ b/pysplit/hyfile_handler.py
@@ -28,7 +28,6 @@ def hysplit_filelister(signature):
         The file search is non-recursive.
 
     """
-
     # Initialize
     orig_dir = os.getcwd()
     matching_files = []
@@ -53,8 +52,7 @@ def hysplit_filelister(signature):
 
 def load_hysplitfile(filename):
     """
-    Load data from each trajectory (a single hysplit file) into a
-    ``NumPy ndarray``.
+    Load data from each trajectory into a ``NumPy ndarray``.
 
     Parameters
     ----------
@@ -76,7 +74,7 @@ def load_hysplitfile(filename):
         The column headers for ``hydata`` arrays.  Used to parse ``hydata``
         into different trajectory attributes
     datetime : DateTime index of length M
-    multiple_traj
+    multiple_traj : Boolean
 
     """
     # Every header- first part

--- a/pysplit/hygroup.py
+++ b/pysplit/hygroup.py
@@ -1,3 +1,6 @@
+import os
+
+
 class HyGroup(object):
     """
     :superclass: for ``TrajectoryGroup`` and ``ClusterGroup``.
@@ -14,29 +17,84 @@ class HyGroup(object):
             ``Trajectory`` instances that belong to the group
 
         """
-
         self.trajectories = trajectories
         self.trajcount = len(trajectories)
 
-    def addgroups(self, other):
+    def __add__(self, other):
         """
-        Create new group from the set of ``Trajectory`` instances
-        in two groups.
+        Add ``HyGroup`` instances.
+
+        Create ``HyGroup`` from the union of two sets of ``Trajectory``
+        instances.
 
         Parameters
         ----------
-        other : ``HyGroup`` or ``HyGroup`` subclass instance
+        other : ``HyGroup`` subclass instance
 
         Returns
         -------
         newgroup : list
-            A list of the unique trajectories from the two groups
+            A list of the unique trajectories from the two groups.
+            Used to make new ``TrajectoryGroup`` instance.
 
         """
-
         set0 = set(self.trajectories)
         set1 = set(other.trajectories)
 
         newgroup = list(set0 | set1)
 
         return newgroup
+
+    def __sub__(self, other):
+        """
+        Subtract ``HyGroup`` instances.
+
+        Create new ``HyGroup`` from the set difference of two
+        sets of ``Trajectory`` instances.
+
+        Parameters
+        ----------
+        other : ``HyGroup`` subclass instance
+
+        Returns
+        -------
+        newgroup : list
+            A list of the set difference of the trajectories.
+            Has has all the elements of ``self`` with the
+            trajectories of ``other`` removed.  Used to
+            make new ``TrajectoryGroup`` instance.
+
+        """
+        set0 = set(self.trajectories)
+        set1 = set(other.trajectories)
+
+        newgroup = list(set0 - set1)
+
+        return newgroup
+
+    def make_infile(self, infile_dir):
+        """
+        Write ``Trajectory`` paths to a file (INFILE).
+
+        Take the member ``Trajectory`` instances and write
+        path to INFILE, used by ``HYSPLIT`` to perform cluster analysis.
+        Can also use this list of files to reinitialize
+        ``TrajectoryGroup``.
+
+        Parameters
+        ----------
+        infile_dir : string
+            The directory in which to create INFILE
+
+        """
+        with open(os.path.join(infile_dir, 'INFILE'), 'w') as infile:
+
+            for traj in self:
+                try:
+                    output = traj.cfullpath
+                except:
+                    output = traj.fullpath
+
+                output = output.replace('\\', '/')
+                infile.writelines(output + '\n')
+                infile.flush()

--- a/pysplit/hypath.py
+++ b/pysplit/hypath.py
@@ -4,11 +4,10 @@ import geopandas as gp
 from shapely.geometry import Point, LineString
 
 
-class HyPath(gp.GeoDataFrame):
+class HyPath(object):
     """
     Class for initializing HySPLIT trajectories and cluster paths.
 
-    :subclass: of ``GeoPandas`` ``GeoDataFrame``.
     :superclass: of ``Trajectory`` and ``Cluster``.
 
     """
@@ -32,20 +31,21 @@ class HyPath(gp.GeoDataFrame):
             The column headers for ``alongpath``.
 
         """
-
         pts = [Point(pathdata[i, :]) for i in range(pathdata.shape[0])]
 
-        gp.GeoDataFrame.__init__(self, data=alongpath[:, 1:],
-                                 columns=header[1:], geometry=pts)
+        self.data = gp.GeoDataFrame(data=alongpath[:, 1:],
+                                    columns=header[1:], geometry=pts)
 
         self.path = LineString(pts)
 
-        self['DateTime'] = datetime
-        self.set_index('Timestep', inplace=True, drop=False)
+        self.data['DateTime'] = datetime
+        self.data.set_index('Timestep', inplace=True, drop=False)
 
     def calculate_vector(self, reverse=False):
         """
-        Calculate the following in radians:
+        Calculate vectors in radians.
+
+        Calculates:
             -The bearings from origin to each timestep
             -The bearings between timesteps (closer to farther from origin)
             -The circular mean of the origin-timestep bearings
@@ -83,7 +83,7 @@ class HyPath(gp.GeoDataFrame):
         bearings_fo = np.arctan2(a, b)
 
         # Set bearings from origin column
-        self[labels[reverse][0]] = bearings_fo
+        self.data[labels[reverse][0]] = bearings_fo
 
         x = np.mean(np.cos(bearings_fo))
         y = np.mean(np.sin(bearings_fo))
@@ -98,12 +98,14 @@ class HyPath(gp.GeoDataFrame):
         bearings_ptp = np.arctan2(a, b)
 
         # point to point bearings column, first entry is 0
-        self[labels[reverse][1]] = 0.0
-        self.loc[self.index[1:], labels[reverse][1]] = bearings_ptp
+        self.data[labels[reverse][1]] = 0.0
+        self.data.loc[self.data.index[1:], labels[reverse][1]] = bearings_ptp
 
     def calculate_distance(self, reverse=False):
         """
-        Calculate the following great circle distances in meters:
+        Calculate great circle distances in meters.
+
+        Calculate great circle distances:
             -Between each timepoint
             -Cumulative along-path travel distance from origin
             -Distance between origin and point
@@ -116,7 +118,6 @@ class HyPath(gp.GeoDataFrame):
             ``self.load_reversetraj()``.
 
         """
-
         which_traj = {False: 'path',
                       True: 'path_r'}
 
@@ -134,20 +135,20 @@ class HyPath(gp.GeoDataFrame):
                                   np.cos(lat[1:]) * np.cos(lat[:-1]) *
                                   np.cos(lon[:-1] - lon[1:])) * 6371) * 1000
 
-        self[labels[reverse][0]] = distance
+        self.data[labels[reverse][0]] = distance
 
-        self[labels[reverse][1]] = np.cumsum(distance)
+        self.data[labels[reverse][1]] = np.cumsum(distance)
 
         dist = (np.arccos(np.sin(lat[1:]) * np.sin(lat[0]) +
                           np.cos(lat[1:]) * np.cos(lat[0]) *
                           np.cos(lon[0] - lon[1:])) * 6371) * 1000
 
-        self[labels[reverse][2]] = 0.0
-        self.loc[self.index[1:], labels[reverse][2]] = dist
+        self.data[labels[reverse][2]] = 0.0
+        self.data.loc[self.index[1:], labels[reverse][2]] = dist
 
     def distance_between2pts(self, coord0, coord1, in_xy=False):
         """
-        Calculate distance between two sets of coordinates
+        Calculate distance between two sets of coordinates.
 
         Parameters
         ----------
@@ -165,7 +166,6 @@ class HyPath(gp.GeoDataFrame):
             Great circle distance in meters.
 
         """
-
         coord0 = np.radians(coord0)
         coord1 = np.radians(coord1)
 
@@ -182,7 +182,7 @@ class HyPath(gp.GeoDataFrame):
 
     def find_destination(self, lat0, lon0, bearing, distance):
         """
-        Find the destination given a bearing and latitude and longitude.
+        Find the destination given bearing, latitude, and longitude.
 
         Parameters
         ----------
@@ -204,7 +204,6 @@ class HyPath(gp.GeoDataFrame):
             Longitude of destination in degrees
 
         """
-
         d2r = distance / 6371000
 
         latr = math.radians(lat0)

--- a/pysplit/traj.py
+++ b/pysplit/traj.py
@@ -42,24 +42,23 @@ class Trajectory(HyPath):
             Location of corresponding clipped HYSPLIT file, if it exists.
 
         """
-
         HyPath.__init__(self, trajdata, pathdata, datetime, trajheader)
 
-        self.rename(columns={'AIR_TEMP': 'Temperature',
-                             'PRESSURE': 'Pressure',
-                             'RAINFALL': 'Rainfall',
-                             'MIXDEPTH': 'Mixing_Depth',
-                             'RELHUMID': 'Relative_Humidity',
-                             'H2OMIXRA': 'Mixing_Ratio',
-                             'SPCHUMID': 'Specific_Humidity',
-                             'SUN_FLUX': 'Solar_Radiation',
-                             'TERR_MSL': 'Terrain_Altitude',
-                             'THETA': 'Potential_Temperature'},
-                    inplace=True)
+        self.data.rename(columns={'AIR_TEMP': 'Temperature',
+                                  'PRESSURE': 'Pressure',
+                                  'RAINFALL': 'Rainfall',
+                                  'MIXDEPTH': 'Mixing_Depth',
+                                  'RELHUMID': 'Relative_Humidity',
+                                  'H2OMIXRA': 'Mixing_Ratio',
+                                  'SPCHUMID': 'Specific_Humidity',
+                                  'SUN_FLUX': 'Solar_Radiation',
+                                  'TERR_MSL': 'Terrain_Altitude',
+                                  'THETA': 'Potential_Temperature'},
+                         inplace=True)
 
-        self['Temperature_C'] = self['Temperature'] - 273.15
-        if self.get('Mixing_Depth') is None:
-            self['Mixing_Depth'] = None
+        self.data['Temperature_C'] = self.data['Temperature'] - 273.15
+        if self.data.get('Mixing_Depth') is None:
+            self.data['Mixing_Depth'] = None
 
         self.folder = folder
         self.filename = filename
@@ -88,7 +87,8 @@ class Trajectory(HyPath):
     def set_rainstatus(self, rainy_criterion='Rainfall', check_steps=0,
                        threshold=0.0):
         """
-        Determines if ``Trajectory`` produced rain during indicated timesteps.
+        Determine if ``Trajectory`` produced rain during indicated timesteps.
+
         Doesn't look at change in specific humidity.
 
         Parameters
@@ -103,41 +103,43 @@ class Trajectory(HyPath):
             ``Relative_Humidity``.
 
         """
-        if self.get(rainy_criterion) is None:
-            raise KeyError(rainy_criterion, " is not in Trajectory.columns")
+        if self.data.get(rainy_criterion) is None:
+            raise KeyError(rainy_criterion, " not in Trajectory.data.columns")
 
         self.rainy = False
 
-        if np.any(self.loc[check_steps, rainy_criterion] > threshold):
+        if np.any(self.data.loc[check_steps, rainy_criterion] > threshold):
             self.rainy = True
 
     def calculate_rh(self):
         """
         Calculate ``Relative_Humidity`` from ``Mixing_Ratio``.
-        Will not execute if ``Relative_Humidity`` is already present.
 
+        Will not execute if ``Relative_Humidity`` is already present.
         Calculation ultimately requires either ``Mixing_Ratio`` or
         ``Specific_Humidity`` as original along-path output variables.
 
         """
         # Check for existence of relative humidity and mixing ratio
-        if self.get('Relative_Humidity') is None:
-            if self.get('Mixing_Ratio') is None:
+        if self.data.get('Relative_Humidity') is None:
+            if self.data.get('Mixing_Ratio') is None:
                 raise KeyError('Calculate mixing ratio first!')
             else:
                 # Convert mixing ratio to relative humidity
-                sat_vapor = 6.11 * (10.0 ** ((7.5 * self['Temperature_C']) /
-                                    (237.7 + self['Temperature_C'])))
+                sat_vapor = 6.11*(10.0**((7.5*self.data['Temperature_C']) /
+                                         (237.7 + self.data['Temperature_C'])))
 
-                sat_w = 621.97 * (sat_vapor / (self['Pressure'] - sat_vapor))
+                sat_w = 621.97 * (sat_vapor / (self.data['Pressure'] -
+                                               sat_vapor))
 
-                self['Relative_Humidity'] = ((self['Mixing_Ratio'] /
-                                              sat_w) * 100.0)
+                self.data['Relative_Humidity'] = ((self.data['Mixing_Ratio'] /
+                                                   sat_w) * 100.0)
 
     def calculate_w(self, calc_using):
         """
-        Calculate ``Mixing_Ratio`` using ``Relative_Humidity`` or
-        ``Specific_Humidity``.
+        Calculate ``Mixing_Ratio``.
+
+        Use either ``Relative_Humidity`` or ``Specific_Humidity``.
         Will not execute if ``Mixing_Ratio`` is already present.
 
         Parameters
@@ -147,9 +149,8 @@ class Trajectory(HyPath):
             [``Relative_Humidity``|``Specific_Humidity``]
 
         """
-
-        if self.get('Mixing_Ratio') is None:
-            if self.get(calc_using) is None:
+        if self.data.get('Mixing_Ratio') is None:
+            if self.data.get(calc_using) is None:
                 raise KeyError(calc_using, ' does not exist.')
             else:
                 func_dict = {'Relative_Humidity': self._convert_rh2w,
@@ -160,24 +161,25 @@ class Trajectory(HyPath):
     def calculate_sh(self):
         """
         Calculate ``Specific_Humidity`` from ``Mixing_Ratio``.
-        Will not execute if ``Specific_Humidity`` is already present.
 
+        Will not execute if ``Specific_Humidity`` is already present.
         Calculation ultimately requires either ``Mixing_Ratio`` or
         ``Relative_Humidity`` as original along-path output variables.
 
         """
-
-        if self.get('Specific_Humidity') is None:
-            if self.get('Mixing_Ratio') is None:
+        if self.data.get('Specific_Humidity') is None:
+            if self.data.get('Mixing_Ratio') is None:
                 raise KeyError('Calculate mixing ratio first!')
             else:
-                w_kg = self['Mixing_Ratio'] / 1000
-                self['Specific_Humidity'] = (w_kg / (w_kg + 1)) * 1000
+                w_kg = self.data['Mixing_Ratio'] / 1000
+                self.data['Specific_Humidity'] = (w_kg / (w_kg + 1)) * 1000
 
     def calculate_moistureflux(self, humidity='Specific_Humidity'):
         """
-        Calculate ``Moisture_Flux`` between each timestep using
-        ``Distance_ptp`` and the indicated humidity type (``humidity``).
+        Calculate ``Moisture_Flux``.
+
+        Moisture flux between each timestep, uses ``Distance_ptp``
+        and the indicated humidity type (``humidity``).
 
         Parameters
         ----------
@@ -187,18 +189,16 @@ class Trajectory(HyPath):
             [``Relative_Humidity``|``Specific_Humidity``]
 
         """
-
-        if self.get(humidity) is None:
+        if self.data.get(humidity) is None:
             print('Calculate ', humidity, ' first!')
         else:
-            if self.get('Distance_ptp') is None:
-                self.calculate_distance()
+            if self.data.get('Distance_ptp') is None:
+                self.data.calculate_distance()
 
-            self['Moisture_Flux'] = None
-            self.loc[self.index[1]:, 'Moisture_Flux'] = ((self['Distance_ptp']/
-                                                          3600).iloc[1:] *
-                                                         self.get(
-                                                         humidity).iloc[:-1])
+            self.data['Moisture_Flux'] = None
+            self.data.loc[self.index[1]:, 'Moisture_Flux'] = (
+                (self.data['Distance_ptp'] / 3600).iloc[1:] *
+                self.data.get(humidity).iloc[:-1])
 
     def moisture_uptake(self, precipitation, evaporation, interval=6,
                         vlim='pbl', pressure_level=900.0,
@@ -242,7 +242,7 @@ class Trajectory(HyPath):
         points = []
 
         # Gives 164, 158, 152, 146 ... 0 etc
-        windows = self.index[::-interval]
+        windows = self.data.index[::-interval]
 
         self.uptake = gp.GeoDataFrame(data=np.empty((windows.size, 13)),
                                       columns=['DateTime', 'Timestep',
@@ -271,32 +271,33 @@ class Trajectory(HyPath):
             # print('interval', self.loc[w: w - (interval - 1), 'Timestep'])
             (self.uptake.loc[w, 'Avg_Pressure'],
              self.uptake.loc[w, 'Avg_MixDepth']) = (
-                self.loc[w: w - (interval - 1),
-                         ['Pressure', 'Mixing_Depth']].mean())
+                self.data.loc[w: w - (interval - 1),
+                              ['Pressure', 'Mixing_Depth']].mean())
 
         # First timestep
         (self.uptake.loc[windows[0], 'DateTime'],
          self.uptake.loc[windows[0], 'Cumulative_Dist'],
          self.uptake.loc[windows[0], 'q']) = (
-            self.loc[windows[0], ['DateTime', 'Cumulative_Dist', humidity]])
+            self.data.loc[windows[0], ['DateTime', 'Cumulative_Dist',
+                                       humidity]])
 
         self.uptake.loc[windows[0], 'unknown_total'] = 1.0
         self.uptake.loc[windows[0], ['above_total', 'below_total']] = 0.0
 
-        points.append(self.loc[windows[0], 'geometry'])
+        points.append(self.data.loc[windows[0], 'geometry'])
 
         for w in windows[1:]:
             (self.uptake.loc[w, 'DateTime'],
              self.uptake.loc[w, 'Cumulative_Dist']) = (
-                 self.loc[w - mdpt, ['DateTime', 'Cumulative_Dist']])
+                 self.data.loc[w - mdpt, ['DateTime', 'Cumulative_Dist']])
 
-            self.uptake.loc[w, 'q'] = self.loc[w, humidity]
+            self.uptake.loc[w, 'q'] = self.data.loc[w, humidity]
 
-            z = np.mean([pt.z for pt in self.loc[w:w - (interval - 1),
-                                                 'geometry']])
+            z = np.mean([pt.z for pt in self.data.loc[w:w - (interval - 1),
+                                                      'geometry']])
 
-            points.append(Point([self.loc[w - mdpt, 'geometry'].x,
-                                 self.loc[w - mdpt, 'geometry'].y, z]))
+            points.append(Point([self.data.loc[w - mdpt, 'geometry'].x,
+                                 self.data.loc[w - mdpt, 'geometry'].y, z]))
 
             # set dq initial for timepoints after the earliest:
             self.uptake.loc[w, 'dq_initial'] = (
@@ -307,7 +308,7 @@ class Trajectory(HyPath):
         self.uptake['geometry'] = points
 
         # Check that mixing depth data actually exists for this trajectory
-        if self.loc[:, 'Mixing_Depth'].all(None):
+        if self.data.loc[:, 'Mixing_Depth'].all(None):
             vlim = 'prs'
         else:
             self.uptake.loc[:, 'Avg_MixDepth'] = (
@@ -393,18 +394,18 @@ class Trajectory(HyPath):
                         self.uptake.loc[is_above, 'above'] *
                         self.uptake.loc[w, 'q'])
 
-    def load_reversetraj(self, reverse_dir, fname_end='REVERSE'):
+    def load_reversetraj(self, reverse_dir='default', fname_end='REVERSE'):
         """
-        Loads reverse trajectory as a LineString, then puts distance info
-        into geodataframe.
+        Load reverse trajectory.
 
-        Multi-trajectory files supported.
+        Load as a LineString, then put distance info into ``self.data``.
+        Multi-trajectory files supported (maybe).
 
         Parameters
         ----------
         reverse_dir : string
-            The location of the reverse trajectories.  Usually a subfolder
-            in ``self.folder``.
+            The location of the reverse trajectories.  Default is a subfolder
+            in ``self.folder`` named 'reversetraj'.
         fname_end : string
             Default 'REVERSE'. Reverse trajectory filename is ``self.filename``
             + fname_end.  This keyword included to grandfather in trajectories
@@ -412,8 +413,10 @@ class Trajectory(HyPath):
             (``fname_end`` = 'FORWARD').
 
         """
-
         if not hasattr(self, 'path_r'):
+
+            if reverse_dir is 'default':
+                reverse_dir = os.path.join(self.folder, 'reversetraj')
 
             if not os.path.isdir(reverse_dir):
                 raise OSError('Reverse trajectory directory does not exist!')
@@ -442,52 +445,50 @@ class Trajectory(HyPath):
 
     def calculate_integrationerr(self):
         """
-        Estimate integration error based on distance between origin and
-        reverse trajectory endpoint and the total travel distance.  Error is
-        in percent.
+        Estimate integration error.
+
+        Integration error based on distance between origin and
+        reverse trajectory endpoint and the total travel distance.
+        Error is in percent.
 
         """
-
-        if self.get('Distance_ptp_r') is None:
+        if self.data.get('Distance_ptp_r') is None:
             raise AttributeError('Reverse trajectory must be loaded first!')
 
-        if self.get('Distance_ptp') is None:
+        if self.data.get('Distance_ptp') is None:
             self.calculate_distance()
 
         site_distance = self.distance_between2pts(self.path.coords[0],
                                                   self.path_r.coords[-1],
                                                   in_xy=True)
 
-        travel_distance = self.loc[:, ['Cumulative_Dist',
-                                       'Cumulative_Dist_r']].iloc[-1].sum()
+        travel_distance = self.data.loc[:,['Cumulative_Dist',
+                                           'Cumulative_Dist_r']].iloc[-1].sum()
 
         self.integration_error = ((site_distance / travel_distance) * 100) / 2
 
     def _convert_rh2w(self):
         """
-        Private function for converting ``Relative_Humidity`` to
-        ``Mixing_Ratio``.
+        Convert ``Relative_Humidity`` to ``Mixing_Ratio``.
 
-        Only called by ``self.calculate_w()``.
+        Only called by ``self.calculate_w()``, private.
 
         """
+        sat_vapor = 6.11 * (10.0 ** ((7.5 * self.data['Temperature_C']) /
+                                     (237.7 + self.data['Temperature_C'])))
 
-        sat_vapor = 6.11 * (10.0 ** ((7.5 * self['Temperature_C']) /
-                                     (237.7 + self['Temperature_C'])))
+        sat_w = 621.97 * (sat_vapor / (self.data['Pressure'] - sat_vapor))
 
-        sat_w = 621.97 * (sat_vapor / (self['Pressure'] - sat_vapor))
-
-        self['Mixing_Ratio'] = (self['Relative_Humidity'] / 100.0) * sat_w
+        self.data['Mixing_Ratio'] = (
+            self.data['Relative_Humidity'] / 100.0) * sat_w
 
     def _convert_q2w(self):
         """
-        Private function for converting ``Specific_Humidity`` to
-        ``Mixing_Ratio``.
+        Convert ``Specific_Humidity`` to ``Mixing_Ratio``.
 
-        Only called by ``self.calculate_w()``.
+        Only called by ``self.calculate_w()``, private.
 
         """
+        q_kg = self.data['Specific_Humidity'] / 1000
 
-        q_kg = self['Specific_Humidity'] / 1000
-
-        self['Mixing_Ratio'] = (q_kg / (1 - q_kg)) * 1000
+        self.data['Mixing_Ratio'] = (q_kg / (1 - q_kg)) * 1000

--- a/pysplit/trajgroup.py
+++ b/pysplit/trajgroup.py
@@ -1,5 +1,4 @@
 from __future__ import division, print_function
-import os
 from hygroup import HyGroup
 
 
@@ -25,67 +24,57 @@ class TrajectoryGroup(HyGroup):
 
     def __getitem__(self, index):
         """
-        Index or slice ``self.trajectories`` to get a ``Trajectory`` or
-        ``TrajectoryGroup``, respectively
+        Get ``Trajectory`` or ``TrajectoryGroup``.
+
+        Parameters
+        ----------
+        index : int or slice
+
+        Returns
+        -------
+        ``Trajectory`` or ``TrajectoryGroup`` depending if indexed
+        or sliced.  Won't return a ``Cluster`` because those are
+        specially defined.
 
         """
-
         newthing = self.trajectories[index]
 
-        # TrajectoryGroup requires a list of Trajectory instances,
-        # but won't fail if given a single Trajectory
         if isinstance(newthing, list):
             newthing = TrajectoryGroup(newthing)
 
         return newthing
 
-    def addgroups(self, other):
+    def __add__(self, other):
         """
-        Create new ``TrajectoryGroup`` from two ``TrajectoryGroup`` instances.
-        Checks for duplicate ``Trajectory`` instances.
+        Add a ``HyGroup`` to this ``TrajectoryGroup`` instance.
 
         Parameters
         ----------
-        other : ``TrajectoryGroup`` or ``Cluster``
-            A different ``TrajectoryGroup`` or ``Cluster`` that may or may not
+        other : ``HyGroup``
+            Another ``TrajectoryGroup`` or ``Cluster``.  May or may not
             contain some of the same ``Trajectory`` instances
 
         Returns
         -------
-        new_self : ``TrajectoryGroup``
-            A new ``TrajectoryGroup`` from the combination of
-            ``self`` and ``other``
+        A new ``TrajectoryGroup`` containing the union of the sets
+        of ``Trajectory`` instances.
 
         """
+        return TrajectoryGroup(HyGroup.__add__(self, other))
 
-        new_tg = TrajectoryGroup(HyGroup.addgroups(self, other))
-
-        return new_tg
-
-    def make_infile(self, infile_dir):
+    def __sub__(self, other):
         """
-        Take ``Trajectory`` instances in ``TrajectoryGroup`` and write
-        path to INFILE, used by ``HYSPLIT`` to perform cluster analysis.
-
-        If a specific subset of ``Trajectory`` instances is needed,
-        create a new ``TrajectoryGroup`` containing only qualifying
-        ``Trajectory`` instances.
+        Subtract a ``HyGroup`` from this ``TrajectoryGroup`` instance.
 
         Parameters
         ----------
-        infile_dir : string
-            The directory in which to create INFILE
+        other : ``HyGroup``
+            Another ``TrajectoryGroup`` or ``Cluster``
+
+        Returns
+        -------
+        A new ``TrajectoryGroup`` containing the set difference between
+        the sets of ``Trajectory`` instances.
 
         """
-
-        with open(os.path.join(infile_dir, 'INFILE'), 'w') as infile:
-
-            for traj in self:
-                try:
-                    output = traj.cfullpath
-                except:
-                    output = traj.fullpath
-
-                output = output.replace('\\', '/')
-                infile.writelines(output + '\n')
-                infile.flush()
+        return TrajectoryGroup(HyGroup.__sub__(self, other))


### PR DESCRIPTION
Instead of subclassing geopandas ``GeoDataFrame``, now the ``HyPath`` ``GeoDataFrame`` lives in the attribute ``data``.  Allows user access to all the geopandas goodies, but won't accidentally end up with ``GeoDataFrames`` instead of ``HyPath`` instances.  Also, by moving ``GeoDataFrame`` to ``data`` attribute, ``Cluster`` can now be indexed and sliced; ``HyGroup`` can have ``__add__()`` method.

Doc updates.  Better conformation to PEP8 standards.

``HyGroup`` now has a ``__sub__()`` method, which performs a set difference.  