### PR TITLE
Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *version.py
 *.egg-info*
+*.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - python: "nightly"
       env: PRE=--pre
   allow_failures:
+    - python: 3.4
     - python : "nightly"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas basemap geopandas
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose coverage flake8 numpy matplotlib pandas basemap geopandas
     # - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas basemap geopandas
   # - source activate test-environment
-  - pip install coveralls 
+  - pip install coveralls
   - python setup.py install
   # - wget https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz
   # - tar -xzvf basemap-1.0.7.tar.gz
@@ -47,9 +47,9 @@ install:
   # - python setup.py install
 
 script:
-  # - python run_tests.py
+  - nosetests pysplit --with-coverage --cover-package=pysplit
 
-  - flake8 --exit-zero pysplit
+  - flake8 --exit-zero --exclude=test_* pysplit
 
 # after_success:
 #   coveralls

--- a/pysplit/clusgroup.py
+++ b/pysplit/clusgroup.py
@@ -1,7 +1,8 @@
 from __future__ import division, print_function
-from trajgroup import TrajectoryGroup
-from hypath import HyPath
-from hygroup import HyGroup
+
+from .trajgroup import TrajectoryGroup
+from .hypath import HyPath
+from .hygroup import HyGroup
 
 
 def print_clusterprocedure():

--- a/pysplit/hy_processor.py
+++ b/pysplit/hy_processor.py
@@ -38,7 +38,7 @@ def make_trajectorygroup(signature):
         folder, _ = os.path.split(signature[0])
         clip = True
     else:
-        hyfiles = hh.hysplit_filelister(signature)
+        hyfiles = hysplit_filelister(signature)
         folder, _ = os.path.split(signature)
         clip = False
 
@@ -64,7 +64,7 @@ def make_trajectorygroup(signature):
             if clip:
                 hyfile = os.path.split(hyfile)[-1]
 
-            data, path, head, datetime, multitraj = hh.load_hysplitfile(hyfile)
+            data, path, head, datetime, multitraj = load_hysplitfile(hyfile)
 
             if multitraj:
                 # Initialize trajectory objects
@@ -113,7 +113,7 @@ def spawn_clusters(trajgroup, distribution_file, endpoint_dir):
 
     """
 
-    traj_inds, totalclusters = hh.load_clusteringresults(distribution_file)
+    traj_inds, totalclusters = load_clusteringresults(distribution_file)
 
     all_clusters = []
 
@@ -126,7 +126,7 @@ def spawn_clusters(trajgroup, distribution_file, endpoint_dir):
         endpt_fname = ('C' + str(cluster_num) + '_' +
                        str(totalclusters) + 'mean.tdump')
         endpt_file = os.path.join(endpoint_dir, endpt_fname)
-        data, pathdata, header, datetime, _ = hh.load_hysplitfile(endpt_file)
+        data, pathdata, header, datetime, _ = load_hysplitfile(endpt_file)
 
         # Make sure longitudes are -180 to 180
         pathdata[:, 1] = np.where(pathdata[:, 1] > 180.0,

--- a/pysplit/hy_processor.py
+++ b/pysplit/hy_processor.py
@@ -1,7 +1,10 @@
 from __future__ import division, print_function
+
 import os
 import numpy as np
-import hyfile_handler as hh
+
+from .hyfile_handler import (load_hysplitfile, load_clusteringresults,
+                             hysplit_filelister)
 from .traj import Trajectory
 from .trajgroup import TrajectoryGroup
 from .clusgroup import Cluster, ClusterGroup

--- a/pysplit/mapdesigner.py
+++ b/pysplit/mapdesigner.py
@@ -1,8 +1,10 @@
 from __future__ import division, print_function
+
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.basemap import Basemap
-import maplabeller as ml
+
+from .maplabeller import map_labeller, labelfile_reader
 
 
 class MapDesign(object):
@@ -121,7 +123,7 @@ class MapDesign(object):
         # Try to set label attributes
         if maplabels is not None:
 
-            self.labels, self.labelstyle = ml.labelfile_reader(maplabels[1])
+            self.labels, self.labelstyle = labelfile_reader(maplabels[1])
             self.labelgroup = maplabels[0]
 
             # Label zorder optional, default 15 if none given.
@@ -300,9 +302,9 @@ class MapDesign(object):
 
         # Draw labels
         if self.labels is not None:
-                basemap = ml.map_labeller(basemap, self.labelgroup,
-                                          self.labels, self.labelstyle,
-                                          self.label_zorder)
+                basemap = map_labeller(basemap, self.labelgroup,
+                                       self.labels, self.labelstyle,
+                                       self.label_zorder)
 
         # Draw countries, states, coastlines, and map boundary
         if self.drawstates:

--- a/pysplit/tests/test_basic.py
+++ b/pysplit/tests/test_basic.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+
+def test_package_import():
+	import pysplit
+
+
+if __name__ == '__main__':
+	np.testing.run_module_suite()

--- a/pysplit/traj.py
+++ b/pysplit/traj.py
@@ -1,11 +1,15 @@
 from __future__ import division, print_function
+
+# External imports
 import os
 import numpy as np
-import geopandas as gp
 import pandas as pd
+import geopandas as gp
 from shapely.geometry import Point, LineString
-import hyfile_handler as hh
-from hypath import HyPath
+
+# Relative imports within the package
+from .hyfile_handler import load_hysplitfile
+from .hypath import HyPath
 
 
 class Trajectory(HyPath):
@@ -433,7 +437,7 @@ class Trajectory(HyPath):
                 raise OSError('File ', self.filename,
                               fname_end, ' not found.')
 
-            _, path, _, _, multitraj = hh.load_hysplitfile(self.rfullpath)
+            _, path, _, _, multitraj = load_hysplitfile(self.rfullpath)
 
             if multitraj:
                 self.path_r = LineString(

--- a/pysplit/trajgroup.py
+++ b/pysplit/trajgroup.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function
-from hygroup import HyGroup
+
+from .hygroup import HyGroup
 
 
 class TrajectoryGroup(HyGroup):


### PR DESCRIPTION
All import statements within a package must be relative in Python 3. Only `from .local_file import stuff` is a valid pattern; `import [local_file]` is no longer recognized.

This PR adds Python 3 compatibility and restores testing Travis build. There is only the most rudimentary test present - it just imports the package - but that is sufficient to prevent regression of Python 3.x support.

A new minor point release is probably warranted.