### PR TITLE
correct support for multitraj file parsing and reverse traj functionality

### DIFF
--- a/pysplit/clusgroup.py
+++ b/pysplit/clusgroup.py
@@ -55,6 +55,7 @@ class Cluster(HyPath, HyGroup):
 
         self.start_longitude = self.trajectories[0].data.loc[0, 'geometry'].x
         self.clusternumber = cluster_number
+        self.multitraj = False
 
     def __getitem__(self, index):
         """

--- a/pysplit/hy_processor.py
+++ b/pysplit/hy_processor.py
@@ -67,11 +67,13 @@ def make_trajectorygroup(signature):
                     # Get rid of parcel number in d
                     # Get rid of parcel #, lat, lon, altitude in head
                     trajectories.append(Trajectory(d, p, dt, head,
-                                                   folder, hyfile, clipdir))
+                                                   folder, hyfile, clipdir,
+                                                   multitraj))
 
             else:
                 trajectories.append(Trajectory(data, path, datetime, head,
-                                               folder, hyfile, clipdir))
+                                               folder, hyfile, clipdir,
+                                               multitraj))
 
         # initialize trajectory group
         trajectories = TrajectoryGroup(trajectories)

--- a/pysplit/hy_processor.py
+++ b/pysplit/hy_processor.py
@@ -62,11 +62,11 @@ def make_trajectorygroup(signature):
 
             if multitraj:
                 # Initialize trajectory objects
-                for d, p in zip(data, path):
+                for d, p, dt in zip(data, path, datetime):
 
                     # Get rid of parcel number in d
                     # Get rid of parcel #, lat, lon, altitude in head
-                    trajectories.append(Trajectory(d, p, datetime, head,
+                    trajectories.append(Trajectory(d, p, dt, head,
                                                    folder, hyfile, clipdir))
 
             else:

--- a/pysplit/hygroup.py
+++ b/pysplit/hygroup.py
@@ -1,8 +1,12 @@
+from __future__ import division, print_function
+
 import os
 
 
 class HyGroup(object):
     """
+    Class for initializing ``HyPath`` container object.
+
     :superclass: for ``TrajectoryGroup`` and ``ClusterGroup``.
 
     """
@@ -119,12 +123,12 @@ class HyGroup(object):
 
     def make_infile(self, infile_dir, use_clippedpath=True):
         """
-        Take ``Trajectory`` instances in ``HyGroup`` and write
-        path to INFILE, used by ``HYSPLIT`` to perform cluster analysis.
+        Write member ``HyPath`` file paths to INFILE.
 
-        If a specific subset of ``Trajectory`` instances is needed,
+        INFILE is used by ``HYSPLIT`` to perform cluster analysis.
+        If a specific subset of ``HyPath`` instances is needed,
         create a new ``HyGroup`` containing only qualifying
-        ``Trajectory`` instances.
+        ``HyPath`` instances.
 
         Parameters
         ----------
@@ -139,14 +143,23 @@ class HyGroup(object):
         with open(os.path.join(infile_dir, 'INFILE'), 'w') as infile:
 
             for traj in self:
-                if use_clippedpath:
+                skip_output = False
+                if traj.multitraj:
                     try:
                         output = traj.cfullpath
-                    except:
-                        output = traj.fullpath
+                    except AttributeError:
+                        print(traj.trajid, " missing clusterable file")
+                        skip_output = True
                 else:
-                    output = traj.fullpath
+                    if use_clippedpath:
+                        try:
+                            output = traj.cfullpath
+                        except AttributeError:
+                            output = traj.fullpath
+                    else:
+                        output = traj.fullpath
 
-                output = output.replace('\\', '/')
-                infile.writelines(output + '\n')
-                infile.flush()
+                if not skip_output:
+                    output = output.replace('\\', '/')
+                    infile.writelines(output + '\n')
+                    infile.flush()

--- a/pysplit/hypath.py
+++ b/pysplit/hypath.py
@@ -41,8 +41,6 @@ class HyPath(object):
         self.data['DateTime'] = datetime
         self.data.set_index('Timestep', inplace=True, drop=False)
 
-        self.parcel_ind = alongpath[0, 0]
-
     def calculate_vector(self, reverse=False):
         """
         Calculate vectors in radians.

--- a/pysplit/hypath.py
+++ b/pysplit/hypath.py
@@ -41,6 +41,8 @@ class HyPath(object):
         self.data['DateTime'] = datetime
         self.data.set_index('Timestep', inplace=True, drop=False)
 
+        self.parcel_ind = alongpath[0, 0]
+
     def calculate_vector(self, reverse=False):
         """
         Calculate vectors in radians.

--- a/pysplit/traj.py
+++ b/pysplit/traj.py
@@ -450,7 +450,7 @@ class Trajectory(HyPath):
             if multitraj:
                 self.path_r = LineString(
                     [Point(path[self.parcel_num - 1][i, :]) for i in
-                     range(path[self.parcel_ind - 1].shape[0])])
+                     range(path[self.parcel_num - 1].shape[0])])
             else:
                 self.path_r = LineString(
                     [Point(path[i, :]) for i in range(path.shape[0])])

--- a/pysplit/traj.py
+++ b/pysplit/traj.py
@@ -21,7 +21,7 @@ class Trajectory(HyPath):
     """
 
     def __init__(self, trajdata, pathdata, datetime, trajheader, folder,
-                 filename, cfolder):
+                 filename, cfolder, multitraj):
         """
         Initialize ``Trajectory``.
 
@@ -44,7 +44,8 @@ class Trajectory(HyPath):
             Path information of HYSPLIT file.
         cfolder : string
             Location of corresponding clipped HYSPLIT file, if it exists.
-
+        multitraj : Boolean
+            If True, is from a file containing multiple trajectories
         """
         HyPath.__init__(self, trajdata, pathdata, datetime, trajheader)
 
@@ -85,6 +86,8 @@ class Trajectory(HyPath):
 
         self.trajcolor = 'black'
         self.linewidth = 2
+        self.multitraj = multitraj
+        self.parcel_num = trajdata[0, 0]
 
     def __hash__(self):
         return hash(self.trajid)
@@ -446,8 +449,8 @@ class Trajectory(HyPath):
 
             if multitraj:
                 self.path_r = LineString(
-                    [Point(path[self.parcel_ind][i, :]) for i in
-                     range(path[self.parcel_ind].shape[0])])
+                    [Point(path[self.parcel_num - 1][i, :]) for i in
+                     range(path[self.parcel_ind - 1].shape[0])])
             else:
                 self.path_r = LineString(
                     [Point(path[i, :]) for i in range(path.shape[0])])


### PR DESCRIPTION
`Trajectory.load_reversetraj()` actually looked for `self.parcel_ind` attribute if reverse trajectory file contents actually contained multiple trajectories.  This attribute was never actually initialized; this PR solves that by initializing at `HyPath` level.

Usually trajectory files that contain multiple trajectories have three trajectories initialized at same point, lasting for same duration.  This is not always the case, particularly for ensemble trajectories that differ in initialization time and lat/lon space.  Previously, the trajectory data was divided into three arrays of equal size.  With this commit, the trajectory data is divided into n arrays of proper size.  Next commit(s) will focus on ensuring proper traj datetime init.