### PR TITLE
FIX for TrajectoryGroup.pop() misbehavior with trajid

### DIFF
--- a/pysplit/clusgroup.py
+++ b/pysplit/clusgroup.py
@@ -134,40 +134,6 @@ class Cluster(HyPath, HyGroup):
         """
         HyPath.calculate_distance(self)
 
-    def pop(self, ind=-1, trajid=None):
-        """
-        Intercept ``HyGroup.pop()``.
-
-        If a list of ``Trajectory`` instances is returned from
-        ``HyGroup.pop()``, return a new ``TrajectoryGroup``,
-        NOT a new ``Cluster``.
-
-        Parameters
-        ----------
-        ind : int
-            Default -1.  The positional argument of the ``Trajectory``
-            to remove.
-        trajid : string
-            Default None.  The named argument of the ``Trajectory``
-            to remove.  Overrides ``ind`` if not None.
-
-        Returns
-        -------
-        popped : ``Trajectory`` instance or ``TrajectoryGroup``
-            The indicated ``Trajectory`` or a ``TrajectoryGroup`` if multiple
-            trajectories were popped out.  May also be a ``None``
-            if no matching ``Trajectory`` instances were found.
-
-        """
-        popped = HyGroup.pop(self, ind, trajid)
-
-        try:
-            popped = TrajectoryGroup(popped)
-        except:
-            pass
-
-        return popped
-
 
 class ClusterGroup(object):
     """

--- a/pysplit/hyfile_handler.py
+++ b/pysplit/hyfile_handler.py
@@ -147,8 +147,8 @@ def load_hysplitfile(filename):
 
                 # Initialize empty data array
                 # 10 dropped columns include date, time step, etc
-                hydata = np.empty((flen, columns - 10))
-                pathdata = np.empty((flen, 3))
+                hydata = np.empty((int(flen), columns - 10))
+                pathdata = np.empty((int(flen), 3))
                 atdata = True
                 arr_ind = 0
                 continue

--- a/pysplit/hygroup.py
+++ b/pysplit/hygroup.py
@@ -77,50 +77,6 @@ class HyGroup(object):
 
         return newgroup
 
-    def pop(self, ind, trajid):
-        """
-        Remove Trajectory object from self.
-
-        Shortcut to self.trajectories.pop() that updates the
-        self.trajcount and the list of trajids.
-
-        Parameters
-        ----------
-        ind : int
-            The positional argument of the ``Trajectory``
-            to remove.
-        trajid : string
-            The named argument of the ``Trajectory``
-            to remove.  Overrides ``ind`` if not None.
-
-        Returns
-        -------
-        popped : ``Trajectory`` instance or list of
-            The indicated ``Trajectory`` or a list if multiple
-            trajectories were popped out.  May also be a ``None``
-            if no matching ``Trajectory`` instances were found.
-
-        """
-        if trajid is not None:
-            popped = []
-            to_pop = [self.trajids.index(s) for s in
-                      self.trajids if trajid in self.trajids]
-            for p in to_pop[::-1]:
-                popped.append(self.trajectories.pop(p))
-                self.trajids.pop(p)
-            self.trajcount = len(self.trajectories)
-            if len(popped) == 0:
-                popped = None
-                print('No trajectories found matching ', trajid)
-            elif len(popped) == 1:
-                popped = popped[0]
-        else:
-            popped = self.trajectories.pop(ind)
-            self.trajids.pop(ind)
-            self.trajcount = len(self.trajectories)
-
-        return popped
-
     def make_infile(self, infile_dir, use_clippedpath=True):
         """
         Write member ``HyPath`` file paths to INFILE.


### PR DESCRIPTION
Used to do a very fun behavior- when popping with a list of ``Trajectory.trajid``, would get rid of all ``Trajectory``s in ``TrajectoryGroup``.  This fixes that.  Also, ``pop()`` was removed from ``HyGroup`` and ``Cluster``, because ``Cluster``s are defined with specific ``Trajectory``s and shouldn't be messed with like that.  Similarly, ``append()`` was initialized as a ``TrajectoryGroup`` method only.