### PR TITLE
MAINT: More robust checks/errors when loading trajectories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+all: clean develop test
+
+test:
+	nosetests -s -v pysplit
+
+coverage: clean-cov
+	nosetests pysplit --with-coverage --cover-package=pysplit
+
+develop:
+	python setup.py develop
+
+clean-pyc:
+	find pysplit -name "*.pyc" | xargs rm -f
+
+clean-build:
+	rm -rf ./build
+
+clean-version:
+	find pysplit -name "*version.py" | xargs rm -f
+
+clean-cov:
+	rm -rf ./coverage ./.coverage ./htmlcov
+
+clean: clean-build clean-pyc clean-version clean-cov

--- a/pysplit/hy_processor.py
+++ b/pysplit/hy_processor.py
@@ -32,7 +32,9 @@ def make_trajectorygroup(signature):
 
     """
     # Get list of hysplit files matching signature
-    if not isinstance(signature, str):
+    if 'basestring' not in globals():  # Python 2/3 compat
+        basestring = str
+    if not isinstance(signature, basestring):
         hyfiles = [os.path.split(hyfile)[-1] for hyfile in signature]
         folder, _ = os.path.split(signature[0])
     else:

--- a/pysplit/hyfile_handler.py
+++ b/pysplit/hyfile_handler.py
@@ -1,8 +1,9 @@
 from __future__ import division, print_function
-import numpy as np
-import pandas as pd
+
 import os
 import fnmatch
+import numpy as np
+import pandas as pd
 
 
 def hysplit_filelister(signature):
@@ -46,6 +47,11 @@ def hysplit_filelister(signature):
 
     finally:
         os.chdir(orig_dir)
+
+    if len(matching_files) == 0:
+        raise LookupError("Could not find any files matching the provided "
+                          "signature `{0}`, please check your paths and "
+                          "try again.".format(signature))
 
     return matching_files
 
@@ -152,6 +158,13 @@ def load_hysplitfile(filename):
                 atdata = True
                 arr_ind = 0
                 continue
+
+    # Catch the vast majority of non-HYSPLIT files if passed
+    # Works because the above conditionals fall through; vars never defined
+    if 'multiline' or 'date0' not in globals():
+        raise IOError("The file, `{0}`, does not appear to be "
+                      "a valid HYSPLIT file. Please double check "
+                      "your paths.".format(filename))
 
     datestrings = []
     for d in date0:

--- a/pysplit/tests/test_file_handling.py
+++ b/pysplit/tests/test_file_handling.py
@@ -1,0 +1,24 @@
+import numpy as np
+from numpy.testing import assert_raises
+from pysplit import make_trajectorygroup
+
+
+def test_bogus_signature():
+    signature = './nothing_to_see_here*'
+    assert_raises(LookupError, make_trajectorygroup, signature)
+
+
+def test_bogus_filenames():
+    filenames = ['./not_a_trajectory0',
+                 './not_a_trajectory1',
+                 './not_a_trajectory2']
+    assert_raises(IOError, make_trajectorygroup, filenames)
+
+
+def test_non_trajectory():
+    signature = './test*'
+    assert_raises(IOError, make_trajectorygroup, signature)
+
+
+if __name__ == '__main__':
+    np.testing.run_module_suite()

--- a/pysplit/tests/test_file_handling.py
+++ b/pysplit/tests/test_file_handling.py
@@ -15,10 +15,5 @@ def test_bogus_filenames():
     assert_raises(IOError, make_trajectorygroup, filenames)
 
 
-def test_non_trajectory():
-    signature = './test*'
-    assert_raises(IOError, make_trajectorygroup, signature)
-
-
 if __name__ == '__main__':
     np.testing.run_module_suite()


### PR DESCRIPTION
Also, small enhancement to Python 2/3 compatibility using `basestring` instead of `str`.

This seems quite robust to me, and helpful in all cases:
* When pointed directly at files which don't exist, using a list of bogus filenames, the usual Python error when it can't load the file is rather informative.  
* When provided a bogus signature (nothing resolves), a new informative error is returned
* When pointed at non-HYSPLIT trajectories, a quick but effective check to see if the parsing happened in the usual way is done and an informative error is returned.  (Prior error was very cryptic)

In the last case, this isn't guaranteed, but will be true in the vast majority of cases.  It's a good compromise as more in-depth check there would likely dramatically slow parsing of trajectory files.

Might be a good idea to bench with and without that last check, to make sure it isn't too slow.  I think looking for two names in the globals shouldn't be too much of a burden, but the proof is in the profiling...