### PR TITLE
ENH: 4 digit year ID, first generator commit

### DIFF
--- a/pysplit/__init__.py
+++ b/pysplit/__init__.py
@@ -27,7 +27,6 @@ __all__ = ['Trajectory',
            'spawn_clusters',
            'hysplit_filelister',
            'load_hysplitfile',
-           'trajsplit',
            'load_clusteringresults',
            'generate_bulktraj']
 
@@ -49,7 +48,7 @@ from .maplabeller import map_labeller, labelfile_reader, labelfile_generator
 
 from .hy_processor import make_trajectorygroup, spawn_clusters
 
-from .hyfile_handler import (hysplit_filelister, load_hysplitfile, trajsplit,
+from .hyfile_handler import (hysplit_filelister, load_hysplitfile,
                              load_clusteringresults)
 
 from .trajectory_generator import (generate_bulktraj)


### PR DESCRIPTION
Opened to resolve #28 , #29 , #30 . Will allow users to choose to identify meteorology files by all 4 digits of a year, or just two, as well as a choice as to outputting 2 or 4 digit years to trajectory file names.  4 digit years will allow correct determination of trajectory century during trajectory loading process.

In progress, this is first pass at trajectory generation part, more commits to follow