### PR TITLE
FIX: backwards Trajectory.uptake.geometry

### DIFF
--- a/pysplit/traj.py
+++ b/pysplit/traj.py
@@ -323,7 +323,7 @@ class Trajectory(HyPath):
                 self.uptake.loc[w - interval, 'q'])
 
         # Set geometry for new gdf
-        self.uptake['geometry'] = points
+        self.uptake['geometry'] = points[::-1]
 
         # Check that mixing depth data actually exists for this trajectory
         if self.data.loc[:, 'Mixing_Depth'].all(None):


### PR DESCRIPTION
Moisture uptake is calculated from the earliest point of a backwards trajectory; the calculation proceeds forwards in time (from bottom to top of Trajectory.data).  The uptake algorithm fills in a new GeoDataFrame (Trajectory.uptake) from the bottom up so that time and direction are in the same orientation as Trajectory.data.  However, geometry, collected from early to recent, is handled differently than other attributes, put in a list prior to inclusion in Trajectory.uptake.  The list now gets reversed prior to inclusion in Trajectory.uptake so it is in the correct direction, fixing the behavior seen in #31