### PR TITLE
Mapzorder

### DIFF
--- a/pysplit/mapdesigner.py
+++ b/pysplit/mapdesigner.py
@@ -20,7 +20,9 @@ class MapDesign(object):
         """
         Initialize ``MapDesign`` instance.
 
-        Is your map blank?  Try changing zmapbound to 10.
+        Is your map blank?  Try changing zmapbound to 10.  Basemap appears to
+        have changed which element (map boundary or background fill) is 
+        prioritized when setting the map boundary zorder.
 
         Parameters
         ----------

--- a/pysplit/mapdesigner.py
+++ b/pysplit/mapdesigner.py
@@ -13,16 +13,14 @@ class MapDesign(object):
     def __init__(self, mapcorners, standard_pm, projection='cyl',
                  mapcolor='light', maplabels=None, area_threshold=10000,
                  resolution='c', zborder=14, zlandfill=12,
-                 zmapbound=16, zlatlon=11, lat_labels=['left'],
+                 zmapbound=10, zlatlon=11, lat_labels=['left'],
                  lon_labels=['top'], latlon_labelspacing=(10, 20),
                  latlon_fs=20, latlon_spacing=(10, 20), drawstates=False,
                  drawoutlines=True, draw_latlons=True, land_alpha=0.85):
         """
         Initialize ``MapDesign`` instance.
 
-        Is your map blank?  Try changing zmapbound to 10.  Basemap appears to
-        have changed which element (map boundary or background fill) is 
-        prioritized when setting the map boundary zorder.
+        Is your map blank?  Try changing zmapbound.
 
         Parameters
         ----------


### PR DESCRIPTION
This is a workaround for the blank map reported in #37 and at least one other issue.  `pysplit.MapDesign()` now includes keyword arguments for setting several z values, including that of the map boundary (`zmapbound`), which depending on one's version of Basemap will apparently either place the map boundary at the top of the stack and the background fill at the specified zorder, creating a blank map (so the user should not use the default value of 16 but something like 10), or the background fill at the bottom and the map boundary at the specified zorder.

Also some PEP8 formatting fixes.

Other new zorder arguments correspond to latitude and longitude, state boundaries, and land fill color; additionally, the land fill color alpha value is now adjustable.