### PR TITLE
test env to fix proj_lib keyerror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 dist: xenial
+services:
+  - xvfb
 language: python
 
 matrix:
@@ -15,9 +17,9 @@ matrix:
     - python: 3.5
     - python : "nightly"
 
-before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+# before_install:
+#   - "export DISPLAY=:99.0"
+#   - "sh -e /etc/init.d/xvfb start"
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 
 matrix:
@@ -39,8 +40,9 @@ install:
 
   # Replace dep1 dep2 ... with your dependencies
   # - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose coverage flake8 numpy matplotlib pandas basemap geopandas
-  - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas basemap geopandas
+  - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas geopandas
   - source activate test-environment
+  - conda install basemap
   - pip install coveralls
   - python setup.py install
   # - wget https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,11 @@ install:
   # - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose coverage flake8 numpy matplotlib pandas basemap geopandas
   - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas geopandas
   - source activate test-environment
-  - conda install basemap
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      conda install -y basemap=1.0.7;
+    else
+      conda install -y basemap;
+    fi
   - pip install coveralls
   - python setup.py install
   # - wget https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ matrix:
     - python: 3.4
     - python: 3.5
     - python: 3.6
+    - python: 3.7
     - python: "nightly"
       env: PRE=--pre
   allow_failures:
     - python: 3.4
+    - python: 3.5
     - python : "nightly"
 
 before_install:
@@ -29,15 +31,16 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   # - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge --force
   - conda update --yes conda
+  - conda config --add channels conda-forge --force
+  
   # Useful for debugging any issues with conda
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose coverage flake8 numpy matplotlib pandas basemap geopandas
-    # - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas basemap geopandas
-  # - source activate test-environment
+  # - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose coverage flake8 numpy matplotlib pandas basemap geopandas
+  - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas basemap geopandas
+  - source activate test-environment
   - pip install coveralls
   - python setup.py install
   # - wget https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,14 @@ install:
 
   # Replace dep1 dep2 ... with your dependencies
   # - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose coverage flake8 numpy matplotlib pandas basemap geopandas
-  - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas geopandas
-  - source activate test-environment
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      conda install -y basemap=1.0.7;
-    else
-      conda install -y basemap;
-    fi
+  - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas basemap geopandas proj4=5.2.0
+  # - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas geopandas
+  # - source activate test-environment
+  # - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+  #     conda install -y basemap=1.0.7;
+  #   else
+  #     conda install -y basemap;
+  #   fi
   - pip install coveralls
   - python setup.py install
   # - wget https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   # - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose coverage flake8 numpy matplotlib pandas basemap geopandas
   - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas basemap geopandas proj4=5.2.0
   # - conda create -y -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip nose flake8 numpy matplotlib pandas geopandas
-  # - source activate test-environment
+  - source activate test-environment
   # - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
   #     conda install -y basemap=1.0.7;
   #   else


### PR DESCRIPTION
Travis CI build failing on Python 3.5 with dependency issues and 2.7 and 3.6 with a PROJ_LIB KeyError.  Move Python 3.5 to allowed failures, add 3.7 as a build, experiment with test environments to overcome travis CI build failing with KeyError PROJ_LIB on 2.7 and 3.6